### PR TITLE
Fixing Soql injection issues.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ ehthumbs.db
 [Dd]esktop.ini
 $RECYCLE.BIN/
 .localdevserver
+
+# IDE files
+.idea/*

--- a/force-app/main/default/classes/Einstein_RecordLanguageController.cls
+++ b/force-app/main/default/classes/Einstein_RecordLanguageController.cls
@@ -4,32 +4,33 @@ public with sharing class Einstein_RecordLanguageController {
 		Schema.SObjectType objectName = recordId.getSObjectType();
 		return objectName.getDescribe().getLabel();
 	}
-	@AuraEnabled(cacheable=true)
-	public static String getLanguagePhrase (Id recordId, String fieldName) {
+
+	@AuraEnabled(Cacheable=true)
+	public static String getLanguagePhrase (Id recordId, final String fieldName) {
 		Schema.SObjectType objectName = recordId.getSObjectType();
 		if(objectName.getDescribe().isAccessible())
 		{
-			// Bind variables fail in cached Apex, apparently.  Use string concatination to build query string
-			String queryString = 'SELECT id, ' + fieldName + ' FROM ' + objectName + ' where id = \'' + recordId + '\' order by id limit 1';
+			String escapedFieldName = String.escapeSingleQuotes(fieldName);
+			// Bind variables fail in cached Apex, apparently.  Use string concatenation to build query string
+			String queryString = 'SELECT id, ' + escapedFieldName + ' FROM ' + objectName + ' where id = \'' + recordId + '\' order by id limit 1';
 			SObject recordItem = Database.query(queryString);
 			System.debug(recordItem);
 			return (String)recordItem.get(fieldName);
 		}
 		else
 		{
-			system.debug('-- fields not accessible ---');
+			System.debug('-- fields not accessible ---');
 			return null;
 		}
-
 	}
 
-	@AuraEnabled(cacheable=true)
+	@AuraEnabled(Cacheable=true)
 	public static List<Einstein_Probability> getRecordAnalysis(Id recordId, String modelId, String fieldName){
 		System.debug('Getting Predictions...' + recordId  + ' ' + modelId + ' ' + fieldName);
 		Schema.SObjectType objectName = recordId.getSObjectType();
 		if(objectName.getDescribe().isAccessible())
 		{
-			// Bind variables fail in cached Apex, apparently.  Use string concatination to build query string
+			// Bind variables fail in cached Apex, apparently.  Use string concatenation to build query string
 			String queryString = 'SELECT id, ' + fieldName + ' FROM ' + objectName + ' where id = \'' + recordId + '\' order by id limit 1';
             SObject recordItem = Database.query(queryString);
             System.debug(recordItem);
@@ -53,14 +54,15 @@ public with sharing class Einstein_RecordLanguageController {
             system.debug('-- fields not accessible ---');
             return null;
         }
-    } 
+    }
+
     @AuraEnabled
     public static void savePredictionValue(Id recordId, String fieldName, String value){
         System.debug(recordId + ' ' + fieldName + ' ' + value);
         // Retrieve the current record
         Schema.SObjectType objectName = recordId.getSObjectType();
         // isAccessible() check done on line 60 before update action
-		// Bind variables fail in cached Apex, apparently.  Use string concatination to build query string
+		// Bind variables fail in cached Apex, apparently.  Use string concatenation to build query string
 		String queryString = 'SELECT id, ' + fieldName + ' FROM ' + objectName + ' where id = \'' + recordId + '\' order by id limit 1';
         SObject recordItem = Database.query(queryString);
         // Update the field value and save the record
@@ -76,5 +78,4 @@ public with sharing class Einstein_RecordLanguageController {
             system.debug('-- fields not accessible ---');
         }
     }
-    
 }

--- a/force-app/main/default/classes/Einstein_RecordLanguageController.cls
+++ b/force-app/main/default/classes/Einstein_RecordLanguageController.cls
@@ -1,12 +1,12 @@
 public with sharing class Einstein_RecordLanguageController {
 	@AuraEnabled
-	public static String getRecordName(Id recordId){
+	public static String getRecordName(final Id recordId){
 		Schema.SObjectType objectName = recordId.getSObjectType();
 		return objectName.getDescribe().getLabel();
 	}
 
 	@AuraEnabled(Cacheable=true)
-	public static String getLanguagePhrase (Id recordId, final String fieldName) {
+	public static String getLanguagePhrase (final Id recordId, final String fieldName) {
 		Schema.SObjectType objectName = recordId.getSObjectType();
 		if(objectName.getDescribe().isAccessible())
 		{
@@ -25,13 +25,14 @@ public with sharing class Einstein_RecordLanguageController {
 	}
 
 	@AuraEnabled(Cacheable=true)
-	public static List<Einstein_Probability> getRecordAnalysis(Id recordId, String modelId, String fieldName){
+	public static List<Einstein_Probability> getRecordAnalysis(final Id recordId, final String modelId, final String fieldName){
 		System.debug('Getting Predictions...' + recordId  + ' ' + modelId + ' ' + fieldName);
 		Schema.SObjectType objectName = recordId.getSObjectType();
 		if(objectName.getDescribe().isAccessible())
 		{
+			String escapedFieldName = String.escapeSingleQuotes(fieldName);
 			// Bind variables fail in cached Apex, apparently.  Use string concatenation to build query string
-			String queryString = 'SELECT id, ' + fieldName + ' FROM ' + objectName + ' where id = \'' + recordId + '\' order by id limit 1';
+			String queryString = 'SELECT id, ' + escapedFieldName + ' FROM ' + objectName + ' where id = \'' + recordId + '\' order by id limit 1';
             SObject recordItem = Database.query(queryString);
             System.debug(recordItem);
 			String text = (String)recordItem.get(fieldName);
@@ -51,19 +52,21 @@ public with sharing class Einstein_RecordLanguageController {
         }
         else
         {
-            system.debug('-- fields not accessible ---');
+            System.debug('-- fields not accessible ---');
             return null;
         }
     }
 
     @AuraEnabled
-    public static void savePredictionValue(Id recordId, String fieldName, String value){
+    public static void savePredictionValue(final Id recordId, final String fieldName, final String value){
         System.debug(recordId + ' ' + fieldName + ' ' + value);
         // Retrieve the current record
         Schema.SObjectType objectName = recordId.getSObjectType();
         // isAccessible() check done on line 60 before update action
+
+		String escapedFieldName = String.escapeSingleQuotes(fieldName);
 		// Bind variables fail in cached Apex, apparently.  Use string concatenation to build query string
-		String queryString = 'SELECT id, ' + fieldName + ' FROM ' + objectName + ' where id = \'' + recordId + '\' order by id limit 1';
+		String queryString = 'SELECT id, ' + escapedFieldName + ' FROM ' + objectName + ' where id = \'' + recordId + '\' order by id limit 1';
         SObject recordItem = Database.query(queryString);
         // Update the field value and save the record
         // 
@@ -75,7 +78,7 @@ public with sharing class Einstein_RecordLanguageController {
         }
         else
         {
-            system.debug('-- fields not accessible ---');
+            System.debug('-- fields not accessible ---');
         }
     }
 }


### PR DESCRIPTION
A security scan reviewed that Einstein_RecordLanguageController could be compromised via a SOQL injection attack. This MR uses String.escapeSingleQuotes() method to help prevent SOQL injection attacks. The primary solution would be to use binding variables, but it looks like that may cause issues with caching.