### PR TITLE
fix  Unexpected character ('<' (code 60))

### DIFF
--- a/force-app/main/default/classes/Einstein_PredictionService.cls
+++ b/force-app/main/default/classes/Einstein_PredictionService.cls
@@ -766,6 +766,11 @@ global with sharing class Einstein_PredictionService {
 	 */
 	global Einstein_PredictionResult predictIntent(String modelId, String text, Integer numResults, String sampleId) {
 		System.debug('Starting predict intent call with model ' + modelId);
+
+		//Fix prediction-unexpected-char. This error happens if the model is trained but the status is never checked explicitly
+		//Error message: Unexpected character ('<' (code 60)): expected a valid value (number, String, array, object, 'true', 'false' or 'null') at input location [1,2]
+		getModel(modelId);
+
 		Einstein_HttpBodyPartPrediction parts = new Einstein_HttpBodyPartPrediction(modelId, text, null, null, numResults, sampleId, Einstein_HttpBodyPartPrediction.Types.DOCUMENT);
 		Einstein_HttpClient client = new Einstein_HttpClient(this, '/intent', parts.build());
 		System.debug('Target URL is ' + client.getUrl());
@@ -798,6 +803,11 @@ global with sharing class Einstein_PredictionService {
 	 */
 	global Einstein_PredictionResult predictSentiment(String modelId, String text, Integer numResults, String sampleId) {
 		System.debug('Starting predict sentiment call with model ' + modelId);
+
+		//Fix prediction-unexpected-char. This error happens if the model is trained but the status is never checked explicitly
+		//Error message: Unexpected character ('<' (code 60)): expected a valid value (number, String, array, object, 'true', 'false' or 'null') at input location [1,2]
+		getModel(modelId);
+
 		Einstein_HttpBodyPartPrediction parts = new Einstein_HttpBodyPartPrediction(modelId, text, null,  null, numResults, sampleId, Einstein_HttpBodyPartPrediction.Types.DOCUMENT);
 		Einstein_HttpClient client = new Einstein_HttpClient(this, '/sentiment', parts.build());
 		System.debug('Target URL is ' + client.getUrl());
@@ -830,6 +840,11 @@ global with sharing class Einstein_PredictionService {
 	 */
 	global Einstein_PredictionResult predictNER(String modelId, String text, Integer numResults, String sampleId) {
 		System.debug('Starting predict NER call with model ' + modelId);
+
+		//Fix prediction-unexpected-char. This error happens if the model is trained but the status is never checked explicitly
+		//Error message: Unexpected character ('<' (code 60)): expected a valid value (number, String, array, object, 'true', 'false' or 'null') at input location [1,2]
+		getModel(modelId);
+
 		Einstein_HttpBodyPartPrediction parts = new Einstein_HttpBodyPartPrediction(modelId, text, null,  null, numResults, sampleId, Einstein_HttpBodyPartPrediction.Types.DOCUMENT);
 		Einstein_HttpClient client = new Einstein_HttpClient(this, '/entities', parts.build());
 		System.debug('Target URL is ' + client.getUrl());


### PR DESCRIPTION
We get "Error message: Unexpected character ('<' (code 60)): expected a valid value (number, String, array, object, 'true', 'false' or 'null') at input location [1,2]" error if the status for a trained model is not explicitly checked. Without checking status - we get a 400 error like below and as a result, the response processor can't handle it as it expects a json.

The fix for this to check the status explicitly during a predict call. 
```
<html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
<title>Error 400 Bad Request</title>
```

![image (1)](https://github.com/SFDC-Assets/EinsteinPlayground/assets/13547968/7eeea265-995e-4461-bbab-752bfa5eeb14)
